### PR TITLE
Feature: Notify user on admin promotion

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -9,6 +9,7 @@ use App\Http\Requests\User\UserStoreRequest;
 use App\Http\Requests\User\UserUpdateRequest;
 use App\Models\User;
 use App\Notifications\SendAccountStateChangedNotification;
+use App\Notifications\UserMadeAdminNotification;
 use App\Notifications\SendNewAccountNotification;
 use App\Notifications\SendNewAccountSetupPasswordNotification;
 use App\Utils\StringUtils;
@@ -84,6 +85,10 @@ class UserController extends Controller
 
         if ($user->isDirty('is_active')) {
             $user->notify(new SendAccountStateChangedNotification());
+        }
+
+        if ($user->isDirty('is_admin') && $user->is_admin) {
+            $user->notify(new UserMadeAdminNotification());
         }
 
         $user->save();

--- a/app/Notifications/UserMadeAdminNotification.php
+++ b/app/Notifications/UserMadeAdminNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class UserMadeAdminNotification extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+                    ->subject(__('notifications.your_status_changed_to_admin_subject'))
+                    ->greeting(__('notifications.greetings_with_name', ['name' => $notifiable->name]))
+                    ->line(__('notifications.you_are_now_admin_line'));
+    }
+}

--- a/lang/en/notifications.php
+++ b/lang/en/notifications.php
@@ -17,4 +17,7 @@ return [
 
     'happy_early_birthday' => 'Happy early birthday!',
     'your_birthday_is_coming_up' => 'Your birthday is coming up soon! Just a reminder that it’s time to create your wishlist and share among family and friends!',
+
+    'your_status_changed_to_admin_subject' => 'Your account status has changed',
+    'you_are_now_admin_line' => 'You have been granted administrator privileges.',
 ];

--- a/lang/fr/notifications.php
+++ b/lang/fr/notifications.php
@@ -17,4 +17,7 @@ return [
 
     'happy_early_birthday' => 'Bonne fête d\'avance!',
     'your_birthday_is_coming_up' => 'Votre date d\'anniversaire arrive à grand pas! Ceci est un rappel qu\'il est temps de créer votre liste de souhaits et de la partager avec la famille et amis!',
+
+    'your_status_changed_to_admin_subject' => 'Votre statut de compte a changé',
+    'you_are_now_admin_line' => 'Des privilèges d\'administrateur vous ont été accordés.',
 ];

--- a/tests/Feature/User/UserTest.php
+++ b/tests/Feature/User/UserTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\User;
 
 use App\Models\User;
 use App\Notifications\SendAccountStateChangedNotification;
+use App\Notifications\UserMadeAdminNotification;
 use App\Notifications\UpcomingBirthdayNotification;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -250,5 +251,84 @@ class UserTest extends TestCase
 
         // ASSERT
         Notification::assertNotSentTo($user, UpcomingBirthdayNotification::class);
+    }
+
+    public function test_sends_notification_when_user_becomes_admin(): void
+    {
+        // SCENARIO 1: User becomes admin
+        Notification::fake();
+
+        $adminUser = User::factory()->create(['is_admin' => true]);
+        $regularUser = User::factory()->create([
+            'name' => 'Regular User',
+            'email' => 'regular@example.com',
+            'is_admin' => false,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($adminUser)
+            ->put(route('users.update', $regularUser), [
+                'name' => $regularUser->name,
+                'email' => $regularUser->email,
+                'is_active' => $regularUser->is_active,
+                'is_admin' => true, // Changed to admin
+                'preferred_locale' => $regularUser->preferred_locale,
+                'birthday_date' => $regularUser->birthday_date ? $regularUser->birthday_date->format('Y-m-d') : null,
+            ]);
+
+        Notification::assertSentTo(
+            $regularUser,
+            UserMadeAdminNotification::class,
+            function ($notification, $channels, $notifiable) use ($regularUser) {
+                return $notifiable->id === $regularUser->id;
+            }
+        );
+        // Ensure it's sent only once for this specific scenario
+        $this->assertEquals(1, Notification::notificationsSent($regularUser, UserMadeAdminNotification::class)->count());
+
+
+        // SCENARIO 2: User was already admin, no notification should be sent
+        Notification::fake(); // Reset notifications for the new scenario
+
+        $alreadyAdminUser = User::factory()->create([
+            'name' => 'Already Admin',
+            'email' => 'alreadyadmin@example.com',
+            'is_admin' => true,
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($adminUser)
+            ->put(route('users.update', $alreadyAdminUser), [
+                'name' => 'Already Admin Updated Name', // Changing name, not admin status
+                'email' => $alreadyAdminUser->email,
+                'is_active' => $alreadyAdminUser->is_active,
+                'is_admin' => true, // Remains admin
+                'preferred_locale' => $alreadyAdminUser->preferred_locale,
+                'birthday_date' => $alreadyAdminUser->birthday_date ? $alreadyAdminUser->birthday_date->format('Y-m-d') : null,
+            ]);
+
+        Notification::assertNotSentTo($alreadyAdminUser, UserMadeAdminNotification::class);
+
+        // SCENARIO 3: User is demoted from admin, no notification should be sent
+        Notification::fake(); // Reset notifications for the new scenario
+
+        $demotedAdminUser = User::factory()->create([
+            'name' => 'Demoted Admin',
+            'email' => 'demoted@example.com',
+            'is_admin' => true, // Starts as admin
+            'is_active' => true,
+        ]);
+
+        $this->actingAs($adminUser)
+            ->put(route('users.update', $demotedAdminUser), [
+                'name' => $demotedAdminUser->name,
+                'email' => $demotedAdminUser->email,
+                'is_active' => $demotedAdminUser->is_active,
+                'is_admin' => false, // Changed to not admin
+                'preferred_locale' => $demotedAdminUser->preferred_locale,
+                'birthday_date' => $demotedAdminUser->birthday_date ? $demotedAdminUser->birthday_date->format('Y-m-d') : null,
+            ]);
+
+        Notification::assertNotSentTo($demotedAdminUser, UserMadeAdminNotification::class);
     }
 }


### PR DESCRIPTION
This commit introduces a notification system to inform you when your account is granted administrator privileges.

The following changes were made:
- A new notification class `UserMadeAdminNotification` was created to handle the email sent to you.
- The `UserController@update` method was modified to detect when the `is_admin` flag is changed to true and then dispatches the notification.
- Feature tests were added to verify that the notification is sent only when you are promoted to admin, and not in other scenarios (e.g., already admin, demoted from admin).
- English and French translations for the new notification messages were added.