### PR TITLE
Refactor: Improve AccordionPanel animation

### DIFF
--- a/resources/js/Components/AccordionPanel.vue
+++ b/resources/js/Components/AccordionPanel.vue
@@ -29,16 +29,17 @@ const isOpen = ref(false);
 <style scoped>
 .accordion-enter-active,
 .accordion-leave-active {
-    transition: max-height 0.3s ease, opacity 0.3s ease;
+    transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+    transform-origin: top;
 }
 .accordion-enter-from,
 .accordion-leave-to {
-    max-height: 0;
+    transform: scaleY(0);
     opacity: 0;
 }
 .accordion-enter-to,
 .accordion-leave-from {
-    max-height: 500px;
+    transform: scaleY(1);
     opacity: 1;
 }
 </style>


### PR DESCRIPTION
I've replaced the `max-height` transition with a `transform: scaleY()` and `opacity` transition for the AccordionPanel component.

This change provides a smoother and less "tacky" animation, as the `scaleY` transform handles variable content heights more gracefully than a fixed `max-height` value. The `transform-origin` is set to `top` for a natural unfolding effect.